### PR TITLE
Add Option/env var IMAGESWAP_INCLUDE_PATH to remove path when rewriting image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGESWAP_VERSION := v1.4.2
+IMAGESWAP_VERSION := v1.4.3
 IMAGESWAP_INIT_VERSION := v0.0.2
 
 REPO_ROOT := $(CURDIR)

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -35,6 +35,7 @@ imageswap_namespace_name = os.getenv("IMAGESWAP_NAMESPACE_NAME", "imageswap-syst
 imageswap_pod_name = os.getenv("IMAGESWAP_POD_NAME")
 imageswap_disable_label = os.getenv("IMAGESWAP_DISABLE_LABEL", "k8s.twr.io/imageswap")
 imageswap_mode = os.getenv("IMAGESWAP_MODE", "MAPS")
+imageswap_with_path = os.getenv("IMAGESWAP_INCLUDE_PATH", "true")
 imageswap_maps_file = os.getenv("IMAGESWAP_MAPS_FILE", "/app/maps/imageswap-maps.conf")
 imageswap_maps_default_key = "default"
 imageswap_maps_wildcard_key = "noswap_wildcards"
@@ -43,7 +44,7 @@ imageswap_maps_wildcard_key = "noswap_wildcards"
 metrics = PrometheusMetrics(app, defaults_prefix="imageswap")
 
 # Static information as metric
-metrics.info("app_info", "Application info", version="v1.2.0")
+metrics.info("app_info", "Application info", version="v1.4.4")
 
 # Set logging config
 log = logging.getLogger("werkzeug")
@@ -333,15 +334,27 @@ def swap_image(container_spec):
                 # If the image prefix ends with "-" just append existing image (minus any ":<port_number>")
                 elif swap_maps[image_registry_key][-1] == "-":
                     if no_registry:
-                        new_image = swap_maps[image_registry_key] + image_registry_noport + "/" + re.sub(r":.*/", "/", image)
+                        if imageswap_with_path.lower() == "false":
+                            new_image = swap_maps[image_registry_key] + image_registry_noport + "/" + re.sub(r"(^.*/)+(.*)", r"\2", image)
+                        else:
+                            new_image = swap_maps[image_registry_key] + image_registry_noport + "/" + re.sub(r":.*/", "/", image)
                     else:
-                        new_image = swap_maps[image_registry_key] + re.sub(r":.*/", "/", image)
+                        if imageswap_with_path.lower() == "false":
+                            new_image = swap_maps[image_registry_key] + re.sub(r"(^.*/)+(.*)", r"/\2", image)
+                        else:
+                            new_image = swap_maps[image_registry_key] + re.sub(r":.*/", "/", image)
                 # If the image registry pattern is found in the original image
                 elif image_registry_key in image:
-                    new_image = re.sub(image_registry_key, swap_maps[image_registry_key], image)
+                    if imageswap_with_path.lower() == "false":
+                        new_image = swap_maps[image_registry_key] + re.sub(r"(^.*/)+(.*)", r"/\2", image)
+                    else:
+                        new_image = re.sub(image_registry_key, swap_maps[image_registry_key], image)
                 # For everything else
                 else:
-                    new_image = swap_maps[image_registry_key] + "/" + image
+                    if imageswap_with_path.lower() == "false":
+                        new_image = swap_maps[image_registry_key] + re.sub(r"(^.*/)+(.*)", r"/\2", image)
+                    else:
+                        new_image = swap_maps[image_registry_key] + "/" + image
 
                 app.logger.debug(f'Swap Map = "{image_registry_key}" : "{swap_maps[image_registry_key]}"')
 
@@ -360,11 +373,21 @@ def swap_image(container_spec):
                     app.logger.debug(f"Default map has no value assigned, skipping swap")
                     return False
                 elif swap_maps[imageswap_maps_default_key][-1] == "-":
-                    new_image = swap_maps[imageswap_maps_default_key] + image_registry_noport + "/" + image
+
+                    if imageswap_with_path.lower() == "false":
+                        new_image = swap_maps[imageswap_maps_default_key] + image_registry_noport + "/" + re.sub(r"(^.*/)+(.*)", r"\2", image)
+                    else:
+                        new_image = swap_maps[imageswap_maps_default_key] + image_registry_noport + "/" + image
                 elif image_registry_key in image:
-                    new_image = re.sub(image_registry, swap_maps[imageswap_maps_default_key], image)
+                    if imageswap_with_path.lower() == "false":
+                        new_image = swap_maps[imageswap_maps_default_key] + re.sub(r"(^.*/)+(.*)", r"/\2", image)
+                    else:
+                        new_image = re.sub(image_registry, swap_maps[imageswap_maps_default_key], image)
                 else:
-                    new_image = swap_maps[imageswap_maps_default_key] + "/" + image
+                    if imageswap_with_path.lower() == "false":
+                        new_image = swap_maps[imageswap_maps_default_key] + "/" + re.sub(r"(^.*/)+(.*)", r"\2", image)
+                    else:
+                        new_image = swap_maps[imageswap_maps_default_key] + "/" + image
 
     # TO-DO (phenixblue): Remove this else block sometime in the future...
     # This "else" block maintains the legacy imageswap logic, which is now
@@ -413,7 +436,14 @@ def main():
     app.logger.info("ImageSwap v1.4.2 Startup")
 
     app.run(
-        host="0.0.0.0", port=5000, debug=False, threaded=True, ssl_context=("./tls/cert.pem", "./tls/key.pem",),
+        host="0.0.0.0",
+        port=5000,
+        debug=False,
+        threaded=True,
+        ssl_context=(
+            "./tls/cert.pem",
+            "./tls/key.pem",
+        ),
     )
 
 

--- a/app/imageswap/test/test_image_patterns.py
+++ b/app/imageswap/test/test_image_patterns.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import sys
+import os
 import unittest
 from unittest.mock import patch
 
@@ -53,6 +54,23 @@ class ImageFormats(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
+    @patch("imageswap.imageswap_with_path", "false")
+    def test_image_format_image_only_no_path(self):
+
+        """Method to test MAP based swap (image only: \"alpine\")"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "alpine"
+
+        expected_image = "my.example.com/mirror-docker.io/alpine"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+        os.environ["IMAGESWAP_INCLUDE_PATH"] = "true"
+
     def test_image_format_image_tag(self):
 
         """Method to test MAP based swap (image+tag: \"nginx:latest\")"""
@@ -81,6 +99,21 @@ class ImageFormats(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
+    @patch("imageswap.imageswap_with_path", "false")
+    def test_image_format_project_image_no_path(self):
+
+        """Method to test MAP based swap (project+image: \"ubuntu/ubuntu\")"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "my_corpo/ubuntu"
+
+        expected_image = "my.example.com/mirror-docker.io/ubuntu"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
     def test_image_format_project_image_tag(self):
 
         """Method to test MAP based swap (project+image+tag: \"ubuntu/ubuntu:latest\")"""
@@ -95,8 +128,22 @@ class ImageFormats(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
-    # Test registry+project+image
+    @patch("imageswap.imageswap_with_path", "false")
+    def test_image_format_project_image_tag_no_path(self):
 
+        """Method to test MAP based swap (project+image+tag: \"ubuntu/ubuntu:latest\")"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "ubuntu/ubuntu:latest"
+
+        expected_image = "my.example.com/mirror-docker.io/ubuntu:latest"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+    # Test registry+project+image
     def test_image_format_registry_project_image(self):
 
         """Method to test MAP based swap (registry+project+image: \"quay.io/solo/gloo\")"""
@@ -106,6 +153,21 @@ class ImageFormats(unittest.TestCase):
         container_spec["image"] = "quay.io/solo/gloo"
 
         expected_image = "quay.example3.com/solo/gloo"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+    @patch("imageswap.imageswap_with_path", "false")
+    def test_image_format_registry_project_image_no_path(self):
+
+        """Method to test MAP based swap (registry+project+image: \"quay.io/solo/gloo\")"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "quay.io/solo/gloo"
+
+        expected_image = "quay.example3.com/gloo"
         result = imageswap.swap_image(container_spec)
 
         self.assertTrue(result)
@@ -125,7 +187,22 @@ class ImageFormats(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
-    def test_image_format_registry_port_project_image_tag(self):
+    def test_image_format_registry_project_image_tag(self):
+
+        """Method to test MAP based swap (registry+project+image+tag: \"quay.io/solo/gloo:v1.0\")"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "quay.io/solo/gloo:v1.0"
+
+        expected_image = "quay.example3.com/solo/gloo:v1.0"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+    @patch("imageswap.imageswap_with_path", "false")
+    def test_image_format_registry_port_project_image_tag_no_path(self):
 
         """Method to test MAP based swap (registry+port+project+image+tag: \"gcr.io:443/istio/istiod:latest\")"""
 
@@ -133,7 +210,7 @@ class ImageFormats(unittest.TestCase):
         container_spec["name"] = "test-container"
         container_spec["image"] = "gcr.io:443/istio/istiod:latest"
 
-        expected_image = "default.example.com/istio/istiod:latest"
+        expected_image = "default.example.com/istiod:latest"
         result = imageswap.swap_image(container_spec)
 
         self.assertTrue(result)
@@ -167,6 +244,21 @@ class ImageFormats(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
+    @patch("imageswap.imageswap_with_path", "false")
+    def test_image_format_nested_project_image_tag_no_path(self):
+
+        """Method to test MAP based swap (nested project+image+tag: \"some/random/test/without/registry-or-tag:latest\")"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "some/random/test/without/registry-or-tag:latest"
+
+        expected_image = "my.example.com/mirror-docker.io/registry-or-tag:latest"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
     def test_image_format_registry_nested_project_image_tag(self):
 
         """Method to test MAP based swap (registry+nested project+image+tag: \"myregistry.com/some/random/test/with/registry:latest\")"""
@@ -176,6 +268,21 @@ class ImageFormats(unittest.TestCase):
         container_spec["image"] = "myregistry.com/some/random/test/with/registry:latest"
 
         expected_image = "default.example.com/some/random/test/with/registry:latest"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+    @patch("imageswap.imageswap_with_path", "false")
+    def test_image_format_registry_nested_project_image_tag_no_path(self):
+
+        """Method to test MAP based swap (registry+nested project+image+tag: \"myregistry.com/some/random/test/with/registry:latest\")"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "myregistry.com/some/random/test/with/registry:latest"
+
+        expected_image = "default.example.com/registry:latest"
         result = imageswap.swap_image(container_spec)
 
         self.assertTrue(result)
@@ -204,6 +311,21 @@ class ImageFormats(unittest.TestCase):
         container_spec["image"] = "kindest/node@sha256:15d3b5c4f521a84896ed1ead1b14e4774d02202d5c65ab68f30eeaf310a3b1a7"
 
         expected_image = "my.example.com/mirror-docker.io/kindest/node@sha256:15d3b5c4f521a84896ed1ead1b14e4774d02202d5c65ab68f30eeaf310a3b1a7"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+    @patch("imageswap.imageswap_with_path", "false")
+    def test_image_format_project_image_digest_no_path(self):
+
+        """Method to test MAP based swap (project+image@digest: \"kindest/node@sha256:15d3b5c4f521a84896ed1ead1b14e4774d02202d5c65ab68f30eeaf310a3b1a7\")"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "kindest/node@sha256:15d3b5c4f521a84896ed1ead1b14e4774d02202d5c65ab68f30eeaf310a3b1a7"
+
+        expected_image = "my.example.com/mirror-docker.io/node@sha256:15d3b5c4f521a84896ed1ead1b14e4774d02202d5c65ab68f30eeaf310a3b1a7"
         result = imageswap.swap_image(container_spec)
 
         self.assertTrue(result)

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -191,7 +191,7 @@ data:
               - "*"
             resources:
               - "pods"
-        failurePolicy: Fail
+        failurePolicy: Ignore
         reinvocationPolicy: IfNeeded
         namespaceSelector:
           matchLabels:
@@ -206,7 +206,7 @@ metadata:
 apiVersion: v1
 data:
   maps: |
-    default:registry.example.com
+    default::registry.example.com
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -296,7 +296,7 @@ spec:
               mountPath: /mwc
       containers:
       - name: imageswap
-        image: thewebroot/imageswap:v1.4.2
+        image: quay.io/plotly/imageswap:v1.4.3
         ports:
         - containerPort: 5000
         command: ["gunicorn", "imageswap:app", "--config=config.py"]


### PR DESCRIPTION
With the env variable `IMAGESWAP_INCLUDE_PATH` set to FALSE  it's possible to use the MAPS configuration system and have the same behaviour as the legacy mode.

https://github.com/plotly/dekn/issues/3172